### PR TITLE
Some fixes and features to make it easier to access data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 /.cache/
 /dist/
+/build/
 /?venv/
 
 *.egg-info/

--- a/src/zenkit/_core.py
+++ b/src/zenkit/_core.py
@@ -54,6 +54,7 @@ _PATH = Path(__file__).parent / "native" / _NAME
 DLL: Final[CDLL] = CDLL(str(_PATH))
 
 PathOrFileLike = Union[str, PathLike, "Read", bytes, bytearray, "VfsNode"]
+DaedalusSymbolValue = Union[float, int, str, "DaedalusInstance", None]
 
 
 class GameVersion(IntEnum):

--- a/src/zenkit/daedalus/__init__.py
+++ b/src/zenkit/daedalus/__init__.py
@@ -44,3 +44,12 @@ _INSTANCES = {
     DaedalusInstanceType.SOUND_EFFECT: SoundEffectInstance,
     DaedalusInstanceType.SOUND_SYSTEM: SoundSystemInstance,
 }
+
+_CLASS_TYPES = {
+    "C_NPC": DaedalusInstanceType.NPC,
+    "C_MISSION": DaedalusInstanceType.MISSION,
+    "C_ITEM": DaedalusInstanceType.ITEM,
+    "C_INFO": DaedalusInstanceType.INFO,
+    "C_ITEMREACT": DaedalusInstanceType.ITEM_REACT,
+    "C_FOCUS": DaedalusInstanceType.FOCUS,
+}

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -141,7 +141,7 @@ class DaedalusSymbol:
 
     def get_instance(self) -> DaedalusInstance:
         value = DLL.ZkDaedalusSymbol_getInstance(self._handle)
-        return DaedalusInstance.from_native(value)
+        return DaedalusInstance.from_native(value, self)
     
     def get_parent_as_symbol(self, find_root: bool = False) -> "DaedalusSymbol | None":
         if self.parent < 0:

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -7,6 +7,7 @@ __all__ = [
 ]
 
 from abc import abstractmethod
+from collections.abc import Generator
 from ctypes import Structure
 from ctypes import c_float
 from ctypes import c_int
@@ -292,9 +293,9 @@ class DaedalusScript:
         return DaedalusScript(_handle=handle, _delete=True)
 
     @property
-    def symbols(self) -> list[DaedalusSymbol]:
+    def symbols(self) -> Generator[DaedalusSymbol]:
         count = DLL.ZkDaedalusScript_getSymbolCount(self._handle)
-        return [self.get_symbol_by_index(i) for i in range(count)]
+        return (self.get_symbol_by_index(i) for i in range(count))
 
     def get_instruction(self, address: int) -> DaedalusInstruction:
         return DLL.ZkDaedalusScript_getInstruction(self._handle, c_size_t(address))

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -20,8 +20,10 @@ from typing import Any
 from typing import ClassVar
 
 from zenkit import _native
+from zenkit.daedalus import _CLASS_TYPES
 from zenkit._core import DLL
 from zenkit._core import PathOrFileLike
+from zenkit._core import DaedalusSymbolValue
 from zenkit._native import ZkPointer
 from zenkit._native import ZkString
 from zenkit.daedalus.base import DaedalusInstance
@@ -204,7 +206,7 @@ class DaedalusSymbol:
         return DaedalusDataType(DLL.ZkDaedalusSymbol_getReturnType(self._handle))
 
     @property
-    def value(self) -> float | int | str | None:
+    def value(self) -> DaedalusSymbolValue:
         if self.type == DaedalusDataType.FLOAT:
             return self.get_float()
         if self.type == DaedalusDataType.INT:

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -192,6 +192,29 @@ class DaedalusSymbol:
     def return_type(self) -> DaedalusDataType:
         return DaedalusDataType(DLL.ZkDaedalusSymbol_getReturnType(self._handle))
 
+    @property
+    def value(self) -> float | int | str | None:
+        if self.type == DaedalusDataType.FLOAT:
+            return self.get_float()
+        if self.type == DaedalusDataType.INT:
+            return self.get_int()
+        if self.type == DaedalusDataType.STRING:
+            return self.get_string()
+        if self.type == DaedalusDataType.INSTANCE:
+            return self.get_instance()
+        return None
+
+    @value.setter
+    def value(self, value: DaedalusSymbolValue):
+        if self.type == DaedalusDataType.FLOAT:
+            self.set_float(value)
+        elif self.type == DaedalusDataType.INT:
+            self.set_int(value)
+        elif self.type == DaedalusDataType.STRING:
+            self.set_string(value)
+        else:
+            raise ValueError(f"Symbol of type {self.type.name} doesn't support value assignment")
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} handle={self._handle} name={self.name!r} type={self.type.name}>"
 

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -231,6 +231,9 @@ class DaedalusSymbol:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} handle={self._handle} name={self.name!r} type={self.type.name}>"
 
+    def __str__(self) -> str:
+        return str(self.value) if self.value is not None else self.name
+
 
 class DaedalusInstruction(Structure):
     _fields_: ClassVar[tuple[str, Any]] = [

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -318,6 +318,17 @@ class DaedalusScript:
             return None
         return DaedalusSymbol(_handle=handle, _keepalive=self)
 
+    def get_parent_symbol(self, child: DaedalusSymbol, find_root: bool = False) -> DaedalusSymbol | None:
+        if child.parent < 0:
+            return None
+
+        symbol = self.get_symbol_by_index(child.parent)
+
+        while find_root and symbol and symbol.parent >= 0:
+            symbol = self.get_symbol_by_index(symbol.parent)
+
+        return symbol
+
     def __del__(self) -> None:
         self._deleter()
 

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -125,13 +125,13 @@ class DaedalusSymbol:
         )
 
     def get_int(self, i: int = 0, ctx: DaedalusInstance | None = None) -> int:
-        return DLL.ZkDaedalusSymbol_getInt(self._handle, c_uint16(i), ctx.handle if ctx else None).value
+        return DLL.ZkDaedalusSymbol_getInt(self._handle, c_uint16(i), ctx.handle if ctx else None)
 
     def set_int(self, val: int, i: int = 0, ctx: DaedalusInstance | None = None) -> None:
         DLL.ZkDaedalusSymbol_setInt(self._handle, c_int32(val), c_uint16(i), ctx.handle if ctx else None)
 
     def get_float(self, i: int = 0, ctx: DaedalusInstance | None = None) -> float:
-        return DLL.ZkDaedalusSymbol_getFloat(self._handle, c_uint16(i), ctx.handle if ctx else None).value
+        return DLL.ZkDaedalusSymbol_getFloat(self._handle, c_uint16(i), ctx.handle if ctx else None)
 
     def set_float(self, val: float, i: int = 0, ctx: DaedalusInstance | None = None) -> None:
         DLL.ZkDaedalusSymbol_setFloat(self._handle, c_float(val), c_uint16(i), ctx.handle if ctx else None)

--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -139,6 +139,17 @@ class DaedalusSymbol:
     def get_instance(self) -> DaedalusInstance:
         value = DLL.ZkDaedalusSymbol_getInstance(self._handle)
         return DaedalusInstance.from_native(value)
+    
+    def get_parent_as_symbol(self, find_root: bool = False) -> "DaedalusSymbol | None":
+        if self.parent < 0:
+            return None
+
+        handle = self._keepalive.get_symbol_by_index(self.parent)
+
+        while find_root and handle and handle.parent >= 0:
+            handle = self._keepalive.get_symbol_by_index(handle.parent)
+
+        return handle
 
     @property
     def is_const(self) -> bool:

--- a/src/zenkit/daedalus_vm.py
+++ b/src/zenkit/daedalus_vm.py
@@ -148,7 +148,7 @@ class DaedalusVm(DaedalusScript):
             sym = self.get_symbol_by_name(sym)
 
         handle = DLL.ZkDaedalusVm_initInstance(self._handle, sym.handle, typ.value).value
-        return DaedalusInstance.from_native(handle)
+        return DaedalusInstance.from_native(handle, sym)
 
     def init_instance_direct(self, sym: DaedalusInstance) -> None:
         DLL.ZkDaedalusVm_initInstanceDirect(self._handle, sym.handle)

--- a/src/zenkit/daedalus_vm.py
+++ b/src/zenkit/daedalus_vm.py
@@ -17,6 +17,7 @@ from zenkit._core import DLL
 from zenkit._core import PathOrFileLike
 from zenkit._native import ZkPointer
 from zenkit._native import ZkString
+from zenkit.daedalus import _CLASS_TYPES
 from zenkit.daedalus.base import DaedalusInstance
 from zenkit.daedalus.base import DaedalusInstanceType
 from zenkit.daedalus_script import DaedalusScript
@@ -141,11 +142,18 @@ class DaedalusVm(DaedalusScript):
         handle = DLL.ZkDaedalusVm_allocInstance(self._handle, sym.handle, typ.value).value
         return DaedalusInstance.from_native(handle)
 
-    def init_instance(self, sym: DaedalusSymbol | str, typ: DaedalusInstanceType) -> DaedalusInstance:
+    def init_instance(self, sym: DaedalusSymbol | str, typ: DaedalusInstanceType = None) -> DaedalusInstance:
         DLL.ZkDaedalusVm_initInstance.restype = ZkPointer
 
         if isinstance(sym, str):
             sym = self.get_symbol_by_name(sym)
+
+        if typ is None:
+            class_sym = self.get_parent_symbol(sym, find_root=True)
+            if class_sym and class_sym.name in _CLASS_TYPES:
+                typ = _CLASS_TYPES[class_sym.name]
+            else:
+                raise ValueError(f"Failed to guess DaedalusInstanceType to init {sym.name}")
 
         handle = DLL.ZkDaedalusVm_initInstance(self._handle, sym.handle, typ.value).value
         return DaedalusInstance.from_native(handle, sym)

--- a/src/zenkit/daedalus_vm.py
+++ b/src/zenkit/daedalus_vm.py
@@ -103,7 +103,7 @@ class DaedalusVm(DaedalusScript):
         elif isinstance(val, str):
             DLL.ZkDaedalusVm_pushString(self._handle, val.encode("windows-1252"))
         else:
-            raise TypeError("Unsupported type: " + type(val))
+            raise TypeError(f"Unsupported type: {type(val)}")
 
     def pop(self, typ: type[DaedalusTypeGeneric]) -> DaedalusTypeGeneric:
         if typ == DaedalusInstance:


### PR DESCRIPTION
I fat fingered the enter key on title and it created an empty PR 🙄 

Anyway, I always wanted to be able to access script data from Python, there is [PyDecDat](https://github.com/Kisioj/PyDecDat) but it doesn't support Ikarus/Lego extended scripts, and iirc was rather slow.
So for now I typically used [DecDat](https://github.com/auronen/DecDat) and parsed the `.d` file with Python to extract data.

When I saw this project I was happy that I don't have to parse the `.d` myself 😄...or so I thought.
Turned out there are some kinks to be straightened out, so I will fix them along the way.
Edits for maintainers are enabled, so if you want to adjust some things, then go ahead :v:

My goal is not to create another DecDat, or so I think for now 🤔 
My goal is to easily extract data, and cross-connected it afterwards in my external scripts.

Example of previously extracted data about dialogues of an NPC together with their possible routines:
```json
"NONE_2246_BRADLOCK": {
  "dialogues": {
    "DIA_BRADLOCK_AFTERMINE": "",
    "DIA_BRADLOCK_AMBIENT": "How are you doing?",
    "DIA_BRADLOCK_CANTPASS": "",
    "Some": "Other"
  },
  "id": 2246,
  "instance_name": "NONE_2246_BRADLOCK",
  "name": "Bradlock",
  "routines": [
    "START",
    "Q308",
    "GUARD",
    "VOLKERTRIALOG",
    "TOT"
  ]
},
```