### PR TITLE
Fix DaedalusSymbol.get_int

### DIFF
--- a/src/zenkit/daedalus_script.py
+++ b/src/zenkit/daedalus_script.py
@@ -125,7 +125,7 @@ class DaedalusSymbol:
         )
 
     def get_int(self, i: int = 0, ctx: DaedalusInstance | None = None) -> int:
-        return DLL.ZkDaedalusSymbol_getInt(self._handle, c_uint16(i), ctx.handle if ctx else None).value
+        return DLL.ZkDaedalusSymbol_getInt(self._handle, c_uint16(i), ctx.handle if ctx else None)
 
     def set_int(self, val: int, i: int = 0, ctx: DaedalusInstance | None = None) -> None:
         DLL.ZkDaedalusSymbol_setInt(self._handle, c_int32(val), c_uint16(i), ctx.handle if ctx else None)


### PR DESCRIPTION
Calling DaedalusSymbol.get_int on a const integer Symbol fails.

Simple test case:
```python
script = DaedalusScript.load(sys.argv[1]) #point to GOTHIC.DAT
# cast is imported from typing and is just there to placate static analysis about the None return:
svm_count = cast(DaedalusSymbol, script.get_symbol_by_name("SVM_MODULES")).get_int()
print(f"SVM count: {svm_count}")
```

Line 2 fails with:
```
    svm_count = cast(DaedalusSymbol, script.get_symbol_by_name("SVM_MODULES")).get_int()
  File "venv/lib/python3.13/site-packages/zenkit/daedalus_script.py", line 128, in get_int
    return DLL.ZkDaedalusSymbol_getInt(self._handle, c_uint16(i), ctx.handle if ctx else None).value
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'value'
```

Removing the `.value` makes this return the expected int value.

(This might also affect `get_float`, but I haven't tested that)