### PR TITLE
fix: class's method and attribute both had the same name

### DIFF
--- a/src/zenkit/core/matrix.py
+++ b/src/zenkit/core/matrix.py
@@ -1,12 +1,9 @@
 import math
 from ctypes import Structure
-from typing import Any
-from typing import ClassVar
-from typing import Union
+from typing import Any, ClassVar, Union
 
 from .quat import Quat
-from .vector import Vec3f
-from .vector import Vec4f
+from .vector import Vec3f, Vec4f
 
 
 class Mat3x3(Structure):
@@ -21,7 +18,9 @@ class Mat3x3(Structure):
         ("columns", Vec3f * 3),
     ]
 
-    def __init__(self, c0: Vec3f = None, c1: Vec3f = None, c2: Vec3f = None) -> "Mat3x3":
+    def __init__(
+        self, c0: Vec3f = None, c1: Vec3f = None, c2: Vec3f = None
+    ) -> "Mat3x3":
         if c0 is None or c1 is None or c2 is None:
             c0 = (1.0, 0.0, 0.0)
             c1 = (0.0, 1.0, 0.0)
@@ -35,9 +34,15 @@ class Mat3x3(Structure):
         Returns:
             A string in the format 'Mat3x3(columns)'.
         """
-        return f"Mat3x3(columns=[\n" f"  {self.columns[0]},\n" f"  {self.columns[1]},\n" f"  {self.columns[2]}\n" f"])"
+        return (
+            f"Mat3x3(columns=[\n"
+            f"  {self.columns[0]},\n"
+            f"  {self.columns[1]},\n"
+            f"  {self.columns[2]}\n"
+            f"])"
+        )
 
-    def columns(self) -> tuple[Vec3f, Vec3f, Vec3f]:
+    def matrix_columns(self) -> tuple[Vec3f, Vec3f, Vec3f]:
         """
         Return the columns of the Matrix as a tuple of Vec3f.
 
@@ -97,7 +102,9 @@ class Mat3x3(Structure):
             return Mat3x3(Vec3f(self.columns[i] - other.columns[i]) for i in range(3))
         raise TypeError("Operand must be of type Mat3x3")
 
-    def __mul__(self, other: Union["Mat3x3", Vec3f, float, int]) -> Union["Mat3x3", Vec3f]:
+    def __mul__(
+        self, other: Union["Mat3x3", Vec3f, float, int]
+    ) -> Union["Mat3x3", Vec3f]:
         """
         Multiply this Matrix by another Matrix, Vector, or scalar.
 
@@ -112,12 +119,22 @@ class Mat3x3(Structure):
         """
         if isinstance(other, Mat3x3):
             result_columns = [
-                Vec3f(*[sum(self.columns[j][k] * other.columns[i][j] for j in range(3)) for k in range(3)])
+                Vec3f(
+                    *[
+                        sum(self.columns[j][k] * other.columns[i][j] for j in range(3))
+                        for k in range(3)
+                    ]
+                )
                 for i in range(3)
             ]
             return Mat3x3(*result_columns)
         elif isinstance(other, Vec3f):
-            return Vec3f(*[sum(self.columns[i][j] * other[i] for i in range(3)) for j in range(3)])
+            return Vec3f(
+                *[
+                    sum(self.columns[i][j] * other[i] for i in range(3))
+                    for j in range(3)
+                ]
+            )
         elif isinstance(other, (int, float)):
             return Mat3x3(Vec3f(self.columns[i] * other) for i in range(3))
         raise TypeError("Operand must be of type Mat3x3, Vec3f, or Number")
@@ -129,7 +146,10 @@ class Mat3x3(Structure):
         Returns:
             A new Mat3x3 instance representing the transposed Matrix.
         """
-        transposed_columns = [Vec3f(self.columns[0][i], self.columns[1][i], self.columns[2][i]) for i in range(3)]
+        transposed_columns = [
+            Vec3f(self.columns[0][i], self.columns[1][i], self.columns[2][i])
+            for i in range(3)
+        ]
         return Mat3x3(*transposed_columns)
 
     def to_euler(self) -> Vec3f:
@@ -228,7 +248,9 @@ class Mat3x3(Structure):
         Returns:
             A new Mat3x3 instance with the applied scaling.
         """
-        scale_matrix = Mat3x3(Vec3f(scale.x, 0, 0), Vec3f(0, scale.y, 0), Vec3f(0, 0, scale.z))
+        scale_matrix = Mat3x3(
+            Vec3f(scale.x, 0, 0), Vec3f(0, scale.y, 0), Vec3f(0, 0, scale.z)
+        )
         return self * scale_matrix
 
     def to_mat4x4(self) -> "Mat4x4":
@@ -267,7 +289,9 @@ class Mat4x4(Structure):
         ("columns", Vec4f * 4),
     ]
 
-    def __init__(self, c0: Vec4f = None, c1: Vec4f = None, c2: Vec4f = None, c3: Vec4f = None) -> "Mat4x4":
+    def __init__(
+        self, c0: Vec4f = None, c1: Vec4f = None, c2: Vec4f = None, c3: Vec4f = None
+    ) -> "Mat4x4":
         if c0 is None or c1 is None or c2 is None or c3 is None:
             c0 = Vec4f(1.0, 0.0, 0.0, 0.0)
             c1 = Vec4f(0.0, 1.0, 0.0, 0.0)
@@ -291,7 +315,7 @@ class Mat4x4(Structure):
             f"])"
         )
 
-    def columns(self) -> tuple[Vec4f, Vec4f, Vec4f, Vec4f]:
+    def matrix_columns(self) -> tuple[Vec4f, Vec4f, Vec4f, Vec4f]:
         """
         Return the columns of the Matrix as a tuple of Vec4f.
 
@@ -351,7 +375,9 @@ class Mat4x4(Structure):
             return Mat4x4(Vec4f(self.columns[i] - other.columns[i]) for i in range(4))
         raise TypeError("Operand must be of type Mat4x4")
 
-    def __mul__(self, other: Union["Mat4x4", Vec4f, float, int]) -> Union["Mat4x4", Vec4f]:
+    def __mul__(
+        self, other: Union["Mat4x4", Vec4f, float, int]
+    ) -> Union["Mat4x4", Vec4f]:
         """
         Multiply this Matrix by another Matrix, Vector, or scalar.
 
@@ -366,12 +392,22 @@ class Mat4x4(Structure):
         """
         if isinstance(other, Mat4x4):
             result_columns = [
-                Vec4f(*[sum(self.columns[j][k] * other.columns[i][j] for j in range(4)) for k in range(4)])
+                Vec4f(
+                    *[
+                        sum(self.columns[j][k] * other.columns[i][j] for j in range(4))
+                        for k in range(4)
+                    ]
+                )
                 for i in range(4)
             ]
             return Mat4x4(*result_columns)
         elif isinstance(other, Vec4f):
-            return Vec4f(*[sum(self.columns[i][j] * other[i] for i in range(4)) for j in range(4)])
+            return Vec4f(
+                *[
+                    sum(self.columns[i][j] * other[i] for i in range(4))
+                    for j in range(4)
+                ]
+            )
         elif isinstance(other, (int, float)):
             return Mat4x4(Vec4f(self.columns[i] * other) for i in range(4))
         raise TypeError("Operand must be of type Mat4x4, Vec4f, or Number")
@@ -384,7 +420,13 @@ class Mat4x4(Structure):
             A new Mat4x4 instance representing the transposed Matrix.
         """
         transposed_columns = [
-            Vec4f(self.columns[0][i], self.columns[1][i], self.columns[2][i], self.columns[3][i]) for i in range(4)
+            Vec4f(
+                self.columns[0][i],
+                self.columns[1][i],
+                self.columns[2][i],
+                self.columns[3][i],
+            )
+            for i in range(4)
         ]
         return Mat4x4(*transposed_columns)
 
@@ -486,7 +528,10 @@ class Mat4x4(Structure):
             A new Mat4x4 instance with the additional scaling applied.
         """
         scale_matrix = Mat4x4(
-            Vec4f(scale.x, 0, 0, 0), Vec4f(0, scale.y, 0, 0), Vec4f(0, 0, scale.z, 0), Vec4f(0, 0, 0, 1)
+            Vec4f(scale.x, 0, 0, 0),
+            Vec4f(0, scale.y, 0, 0),
+            Vec4f(0, 0, scale.z, 0),
+            Vec4f(0, 0, 0, 1),
         )
         return self * scale_matrix
 


### PR DESCRIPTION
This commit renames `Mat3x3` and `Mat4x4` classes method `columns` to `matrix_columns` to avoid ambiguity since both classes also have class attributes that had the same name which was triggering lots of LSP warnings.